### PR TITLE
fixed texture uploading for rpi zero 2w

### DIFF
--- a/gs/src/Video_Decoder.cpp
+++ b/gs/src/Video_Decoder.cpp
@@ -303,6 +303,10 @@ size_t Video_Decoder::lock_output()
         LOGI("Texture: {}", output.texture);
     }
 
+#if defined(IMGUI_IMPL_OPENGL_ES2)
+    GLCHK(glBindTexture(GL_TEXTURE_2D, output.texture));
+    GLCHK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, output.width, output.height, 0, GL_RGB, GL_UNSIGNED_BYTE, output.rgb_data.data()));
+#else
     //calculate total size
     GLCHK(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, output.pbo));
     size_t pbo_size = output.rgb_data.size();
@@ -325,6 +329,7 @@ size_t Video_Decoder::lock_output()
     GLCHK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, output.width, output.height, 0, GL_RGB, GL_UNSIGNED_BYTE, 0));
 
     GLCHK(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0));
+#endif
 
     m_texture = output.texture;
     m_resolution = ImVec2((float)output.width, (float)output.height);


### PR DESCRIPTION
glBindBuffer(GL_PIXEL_UNPACK_BUFFER, output.pbo) is **not** available in ES2.0 profile. It is part of ES3.0 profile.
Texture upload fails on RPI Zero 2 W. ES2.0 profile should use direct texture upload.

Note: It is available in Opengl CORE 2.0 profile as extension ARB_pixel_buffer_object which is present on RPI Zero 2W. 
However my tests show that runnig Core profile with PIXEL_UNPACK_BUFFER works significantly slower then direct texture uploading with ES2.0 profile. 

With CORE 2.0 profile it barely keeps 20 FPS 640x480 due to slow texture uploading. With ES20 direc texture uploading it works fine at 800x600 30 fps.